### PR TITLE
fix: omit header when saving feature list

### DIFF
--- a/utils/build_dataset.py
+++ b/utils/build_dataset.py
@@ -488,7 +488,7 @@ def generate_dataset(
     # Save selected feature names
     os.makedirs(output_dir, exist_ok=True)
     feature_name_path = os.path.join(output_dir, f"selected_features_{version}.csv")
-    pd.Series(selected_features).to_csv(feature_name_path, index=False)
+    pd.Series(selected_features).to_csv(feature_name_path, index=False, header=False)
     print(f"💾 Saved selected feature names to {feature_name_path}")
     
     # 8. PCA Transformation (with preservation)


### PR DESCRIPTION
## Summary
- avoid writing a header row when dumping selected features

## Testing
- `python -m py_compile utils/build_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68403d4103d88320ad84e828df0fddef