### PR TITLE
Add higher-interval feature aggregation

### DIFF
--- a/tests/test_build_features.py
+++ b/tests/test_build_features.py
@@ -24,3 +24,20 @@ def test_build_features_basic():
     assert "rsi_14" in features.columns
     assert pd.api.types.is_numeric_dtype(features["return_1h"])
     assert pd.api.types.is_numeric_dtype(features["rsi_14"])
+
+
+def test_build_features_higher_interval():
+    rng = pd.date_range("2021-01-01", periods=60, freq="H")
+    base = np.linspace(100, 160, num=60)
+    df = pd.DataFrame({
+        "open": base,
+        "high": base + 1,
+        "low": base - 1,
+        "close": base + 0.5,
+        "volume": np.linspace(1000, 1060, num=60),
+    }, index=rng)
+
+    features = build_features(df, higher_intervals=["4H"])
+
+    assert "rsi_14_4H" in features.columns
+    assert "close_ma_3_4H" in features.columns


### PR DESCRIPTION
## Summary
- add optional `higher_intervals` arg to `build_features`
- resample OHLCV to higher intervals and compute SMA/RSI
- propagate intervals through `generate_dataset`
- test higher interval feature creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840441174148320b0d7021f336fac37