### PR TITLE
Add Williams %R, StochRSI and Aroon indicators

### DIFF
--- a/tests/test_build_features.py
+++ b/tests/test_build_features.py
@@ -22,5 +22,9 @@ def test_build_features_basic():
 
     assert "return_1h" in features.columns
     assert "rsi_14" in features.columns
+    assert "willr_14" in features.columns
+    assert "stochrsi_14" in features.columns
+    assert "aroon_up_14" in features.columns
+    assert "aroon_down_14" in features.columns
     assert pd.api.types.is_numeric_dtype(features["return_1h"])
     assert pd.api.types.is_numeric_dtype(features["rsi_14"])

--- a/utils/build_dataset.py
+++ b/utils/build_dataset.py
@@ -13,12 +13,15 @@ from ta.volatility import (
 from ta.momentum import (
     RSIIndicator,
     StochasticOscillator,
-    ROCIndicator
+    ROCIndicator,
+    WilliamsRIndicator,
+    StochRSIIndicator,
 )
 from ta.trend import (
     MACD,
     ADXIndicator,
-    CCIIndicator
+    CCIIndicator,
+    AroonIndicator,
 )
 from ta.volume import (
     OnBalanceVolumeIndicator,
@@ -115,6 +118,14 @@ def build_features(df_raw: pd.DataFrame, min_periods: int = 24) -> pd.DataFrame:
     for w in [10, 14, 20]:
         df[f"roc_{w}"] = ROCIndicator(df["close"], window=w).roc()
 
+    for w in [7, 14, 21]:
+        df[f"willr_{w}"] = WilliamsRIndicator(
+            df["high"], df["low"], df["close"], lbp=w
+        ).williams_r()
+        df[f"stochrsi_{w}"] = StochRSIIndicator(
+            df["close"], window=w
+        ).stochrsi()
+
     for fast, slow in [(12, 26), (10, 20), (8, 16)]:
         macd = MACD(
             df["close"], window_slow=slow, window_fast=fast
@@ -132,6 +143,11 @@ def build_features(df_raw: pd.DataFrame, min_periods: int = 24) -> pd.DataFrame:
         df[f"di_plus_{w}"] = adx.adx_pos()
         df[f"di_minus_{w}"] = adx.adx_neg()
         df[f"cci_{w}"] = CCIIndicator(df["high"], df["low"], df["close"], window=w).cci()
+
+    for w in [14, 20, 28]:
+        aroon = AroonIndicator(df["high"], df["low"], window=w)
+        df[f"aroon_up_{w}"] = aroon.aroon_up()
+        df[f"aroon_down_{w}"] = aroon.aroon_down()
 
     # ======================
     # Volatility Indicators


### PR DESCRIPTION
## Summary
- extend TA-lib imports for new indicators
- compute Williams %R, StochRSI and Aroon indicator features
- check for the new features in unit tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840441c49b88320ab7c8ef714158e74