### PR TITLE
Add external data support to dataset builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI Trading Bot Dataset Generation
 
-This repository contains utilities for building feature-rich datasets from crypto price data.
+This repository contains utilities for building feature-rich datasets from crypto price data. Input
+CSV files should provide `open`, `high`, `low`, `close` and `volume` columns indexed by timestamp.
 
 ## GPU Acceleration
 
@@ -29,4 +30,19 @@ generate_dataset(
 ```
 
 If `use_gpu` is disabled (default), CPU implementations are used.
+
+### Additional Market Data
+
+`build_features` and `generate_dataset` accept an optional `extra_data` argument:
+
+```python
+extra = {"btc": btc_df, "sp500": sp500_df}
+df = build_features(df, extra_data=extra)
+```
+
+Each dataframe in `extra_data` must use a timestamp index and provide at least a
+`close` column. Basic indicators—hourly and 24‑hour returns plus a 24‑hour
+moving average—are computed and merged into the feature set with suffixes such
+as `return_1h_btc` or `close_ma_24_sp500`. Missing timestamps are gracefully
+forward‑filled during processing.
 

--- a/tests/test_build_features.py
+++ b/tests/test_build_features.py
@@ -24,3 +24,23 @@ def test_build_features_basic():
     assert "rsi_14" in features.columns
     assert pd.api.types.is_numeric_dtype(features["return_1h"])
     assert pd.api.types.is_numeric_dtype(features["rsi_14"])
+
+
+def test_build_features_with_extra():
+    rng = pd.date_range("2021-01-01", periods=60, freq="H")
+    base = np.linspace(50, 110, num=60)
+    df = pd.DataFrame({
+        "open": base,
+        "high": base + 1,
+        "low": base - 1,
+        "close": base + 0.5,
+        "volume": np.linspace(500, 560, num=60),
+    }, index=rng)
+
+    extra_close = pd.DataFrame({"close": np.linspace(1000, 1120, num=60)}, index=rng)
+
+    features = build_features(df, extra_data={"btc": extra_close})
+
+    assert "return_1h_btc" in features.columns
+    assert "close_ma_24_btc" in features.columns
+


### PR DESCRIPTION
## Summary
- allow `build_features` and `generate_dataset` to merge extra market data
- document the new optional argument in README
- unit test verifying additional features

## Testing
- `pip install pandas numpy scikit-learn xgboost ta matplotlib seaborn jupyter joblib lightgbm`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840441dade88320af63ad95f1ae5c05