### PR TITLE
Fix pandas deprecation warnings

### DIFF
--- a/tests/test_build_features.py
+++ b/tests/test_build_features.py
@@ -8,7 +8,7 @@ from utils.build_dataset import build_features
 
 def test_build_features_basic():
     # Create deterministic sample data
-    rng = pd.date_range("2021-01-01", periods=60, freq="H")
+    rng = pd.date_range("2021-01-01", periods=60, freq="h")
     base = np.linspace(100, 160, num=60)
     df = pd.DataFrame({
         "open": base,
@@ -33,7 +33,7 @@ def test_build_features_basic():
 
 
 def test_build_features_unsupervised():
-    rng = pd.date_range("2021-01-01", periods=64, freq="H")
+    rng = pd.date_range("2021-01-01", periods=64, freq="h")
     base = np.linspace(100, 164, num=64)
     df = pd.DataFrame(
         {
@@ -53,7 +53,7 @@ def test_build_features_unsupervised():
 
 
 def test_build_features_higher_intervals():
-    rng = pd.date_range("2021-01-01", periods=60, freq="H")
+    rng = pd.date_range("2021-01-01", periods=60, freq="h")
     base = np.linspace(100, 160, num=60)
     df = pd.DataFrame(
         {

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -6,7 +6,7 @@ from utils.build_dataset import feature_selection
 
 
 def _dummy_data(n_samples=30, n_features=8):
-    rng = pd.date_range("2021-01-01", periods=n_samples, freq="H")
+    rng = pd.date_range("2021-01-01", periods=n_samples, freq="h")
     X = pd.DataFrame(
         np.random.randn(n_samples, n_features),
         index=rng,


### PR DESCRIPTION
## Summary
- update pandas date_range calls in tests to use lowercase `freq="h"`

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68408573cb048320a482e145edef044a