### PR TITLE
Fix dataset paths in training examples

### DIFF
--- a/examples/train_classification.ipynb
+++ b/examples/train_classification.ipynb
@@ -41,6 +41,8 @@
    "outputs": [],
    "source": [
     "base = Path(\"data/processed/classification\")\n",
+    "if not base.exists():\n",
+    "    base = Path('..') / base\n",
     "X = pd.read_parquet(base / \"X_v1.parquet\")\n",
     "y = pd.read_parquet(base / \"y_v1.parquet\").squeeze()\n",
     "\n",

--- a/examples/train_classification.py
+++ b/examples/train_classification.py
@@ -19,7 +19,8 @@ import seaborn as sns
 
 
 def main():
-    base = Path("data/processed/classification")
+    repo_root = Path(__file__).resolve().parents[1]
+    base = repo_root / "data/processed/classification"
     X = pd.read_parquet(base / "X_v1.parquet")
     y = pd.read_parquet(base / "y_v1.parquet").squeeze()
 


### PR DESCRIPTION
## Summary
- make training script resolve dataset paths relative to repo root
- make notebook robust to being run from `examples/`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a8ba27008320bd972b28545d42df