### PR TITLE
Add optional RBF cyclical features

### DIFF
--- a/tests/test_build_features.py
+++ b/tests/test_build_features.py
@@ -70,3 +70,22 @@ def test_build_features_higher_intervals():
 
     assert "rsi_14_4H" in features.columns
     assert "close_ma_3_4H" in features.columns
+
+
+def test_build_features_rbf():
+    rng = pd.date_range("2021-01-01", periods=60, freq="h")
+    base = np.linspace(100, 160, num=60)
+    df = pd.DataFrame(
+        {
+            "open": base,
+            "high": base + 1,
+            "low": base - 1,
+            "close": base + 0.5,
+            "volume": np.linspace(1000, 1060, num=60),
+        },
+        index=rng,
+    )
+
+    features = build_features(df, cyclical="rbf")
+
+    assert "hour_rbf1" in features.columns

--- a/utils/build_dataset.py
+++ b/utils/build_dataset.py
@@ -50,6 +50,8 @@ def build_features(
     unsupervised: bool = False,
     higher_intervals: list[str] | None = None,
     extra_data: dict[str, pd.DataFrame] | None = None,
+    cyclical: str = "sin",
+    rbf_sigma: float = 1.0,
 ) -> pd.DataFrame:
     """
     Enhanced feature engineering (long-only) — constructs a wide range of technical
@@ -72,6 +74,11 @@ def build_features(
         resample the raw data and add coarse features.
     extra_data:
         Optional dictionary of additional market data dataframes keyed by name.
+    cyclical:
+        "sin" for sine/cosine encoding, "rbf" for radial basis functions or
+        "both" to include all cyclical features.
+    rbf_sigma:
+        Width parameter for radial basis function time features.
     """
     df = df_raw.copy()
     df = df[~df.index.duplicated(keep="first")]
@@ -367,9 +374,18 @@ def build_features(
         "month": df.index.month,
     }
 
+
     for col, period in [("hour", 24), ("dow", 7), ("month", 12)]:
-        time_cols[f"{col}_sin"] = np.sin(2 * np.pi * time_cols[col] / period)
-        time_cols[f"{col}_cos"] = np.cos(2 * np.pi * time_cols[col] / period)
+        if cyclical in ("sin", "both"):
+            time_cols[f"{col}_sin"] = np.sin(2 * np.pi * time_cols[col] / period)
+            time_cols[f"{col}_cos"] = np.cos(2 * np.pi * time_cols[col] / period)
+
+        if cyclical in ("rbf", "both"):
+            centers = [0, period / 2]
+            for i, c in enumerate(centers, start=1):
+                time_cols[f"{col}_rbf{i}"] = np.exp(
+                    -0.5 * ((time_cols[col] - c) / rbf_sigma) ** 2
+                )
 
     df = df.assign(**time_cols)
 


### PR DESCRIPTION
## Summary
- add `cyclical` and `rbf_sigma` params to `build_features`
- allow sine/cosine or RBF-based time encodings
- expose RBF feature names like `hour_rbf1`
- test for presence of RBF features

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c676e6c48320b8b26a290b204d8c