### PR TITLE
Add optional regime target encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ generate_dataset(
     version="v1",
     task="classification",
     horizon=3,
+    regime_target_encoding=True,
 )
 ```
+
+When enabled, the market ``regime`` feature is encoded against the target
+variable using `category_encoders.TargetEncoder`.
 
 ### GPU Acceleration
 Set `use_gpu=True` when calling `generate_dataset` to enable faster feature

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ seaborn
 jupyter
 joblib
 PyWavelets
+category_encoders
+pyarrow

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -1,0 +1,38 @@
+import os, sys
+import pandas as pd
+import numpy as np
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.build_dataset import generate_dataset
+
+
+def test_generate_dataset_regime_encoding(tmp_path):
+    n = 1100
+    rng = pd.date_range("2021-01-01", periods=n, freq="h")
+    np.random.seed(0)
+    base = 100 + np.cumsum(np.random.randn(n))
+    df = pd.DataFrame({
+        "timestamp": rng,
+        "open": base,
+        "high": base + np.random.rand(n),
+        "low": base - np.random.rand(n),
+        "close": base + 0.5 * np.random.randn(n),
+        "volume": 1000 + np.random.rand(n) * 10,
+    })
+
+    raw_csv = tmp_path / "raw.csv"
+    df.to_csv(raw_csv, index=False)
+    out_dir = tmp_path / "out"
+
+    generate_dataset(
+        raw_path=str(raw_csv),
+        output_dir=str(out_dir),
+        version="tst",
+        task="classification",
+        regime_target_encoding=True,
+    )
+
+    feat_file = out_dir / "selected_features_tst.csv"
+    selected = pd.read_csv(feat_file, header=None)[0].tolist()
+    assert "regime_te" in selected

--- a/utils/build_dataset.py
+++ b/utils/build_dataset.py
@@ -462,7 +462,9 @@ def build_features(
             df["regime_change"] = (
                 df["regime"].diff().abs().gt(0).astype(int)
             )
+            regime_numeric = df["regime"].copy()
             df = pd.get_dummies(df, columns=["regime"], prefix="regime")
+            df["regime"] = regime_numeric
         except Exception as e:
             print(f"⚠️ Market regime detection failed: {e}")
 
@@ -672,6 +674,7 @@ def generate_dataset(
     horizon: int = 3,
     clean: bool = True,
     use_gpu: bool = False,
+    regime_target_encoding: bool = False,
     extra_data: dict[str, pd.DataFrame] | None = None,
 ):
     """Complete dataset generation pipeline.
@@ -689,6 +692,8 @@ def generate_dataset(
         use_gpu: forward to feature_selection for GPU acceleration
         extra_data: optional dictionary of additional price data passed through
             to ``build_features`` for feature augmentation.
+        regime_target_encoding: apply target encoding to the ``regime`` column
+            after label creation if present.
     """
     # 1. Load and prepare data
     df = pd.read_csv(raw_path, parse_dates=["timestamp"], index_col="timestamp")
@@ -706,6 +711,18 @@ def generate_dataset(
         label_col = "y_ratio"
     else:
         raise ValueError("Task must be 'classification' or 'regression'")
+
+    # 3b. Optional target encoding of market regime
+    if regime_target_encoding and "regime" in df.columns:
+        try:
+            from category_encoders import TargetEncoder
+
+            target_col = "y_class" if task == "classification" else "y_ratio"
+            te = TargetEncoder(cols=["regime"])
+            encoded = te.fit_transform(df[["regime"]], df[target_col])
+            df["regime_te"] = encoded["regime"]
+        except Exception as e:
+            print(f"⚠️ Regime target encoding failed: {e}")
     
     # 4. Clean data
     if clean:
@@ -746,6 +763,10 @@ def generate_dataset(
             task="classification",
             use_gpu=use_gpu,
         )
+
+    if regime_target_encoding and "regime_te" in X.columns:
+        if "regime_te" not in selected_features:
+            selected_features = list(selected_features) + ["regime_te"]
 
     X_sel = X[selected_features]
     


### PR DESCRIPTION
## Summary
- add category_encoders and pyarrow requirements
- keep numeric regime column and optionally target encode it in dataset generation
- ensure selected features always keep `regime_te`
- document new `regime_target_encoding` flag
- test dataset generation with target encoding

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c6e2ebb483208c1c994ea55816cd