### PR TITLE
Add optional importance pruning to feature_selection

### DIFF
--- a/examples/train_classification.py
+++ b/examples/train_classification.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import pandas as pd
 from joblib import dump
+from utils import feature_selection
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import cross_val_score
 from sklearn.metrics import (
@@ -29,6 +30,18 @@ def main():
     split_idx = int(len(X) * 0.8)
     X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
     y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+
+    # Optional permutation importance pruning after feature selection
+    selected = feature_selection(
+        X_train,
+        y_train,
+        n_features=40,
+        task="classification",
+        importance_method="permutation",
+        importance_threshold=0.01,
+    )
+    X_train = X_train[selected]
+    X_test = X_test[selected]
 
     lr = LogisticRegression(max_iter=1000)
     # Cross-validation on the training portion

--- a/tests/test_feature_selection.py
+++ b/tests/test_feature_selection.py
@@ -48,3 +48,30 @@ def test_feature_selection_gpu_tree_method():
 
     assert calls["kwargs"]["tree_method"] == "gpu_hist"
     assert len(selected) == 4
+
+
+def test_feature_selection_permutation_pruning():
+    X, y = _dummy_data()
+
+    class DummyRF:
+        def fit(self, X, y):
+            pass
+
+    class DummyResult:
+        importances_mean = np.array([0.1, 0.05, 0.001, 0.2, 0.3, 0.0, 0.04, 0.02])
+
+    with patch("utils.build_dataset.RandomForestClassifier", return_value=DummyRF()):
+        with patch("utils.build_dataset.permutation_importance", return_value=DummyResult()):
+            with patch("utils.build_dataset.RFE") as DummyRFE:
+                DummyRFE.return_value.fit.return_value = None
+                DummyRFE.return_value.support_ = np.array([True] * X.shape[1])
+                selected = feature_selection(
+                    X,
+                    y,
+                    n_features=8,
+                    task="classification",
+                    importance_method="permutation",
+                    importance_threshold=0.05,
+                )
+
+    assert len(selected) == 4

--- a/utils/build_dataset.py
+++ b/utils/build_dataset.py
@@ -34,9 +34,15 @@ from sklearn.feature_selection import (
     RFE,
     VarianceThreshold,
     SequentialFeatureSelector,
-    mutual_info_regression
+    mutual_info_regression,
 )
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, GradientBoostingRegressor, RandomForestRegressor
+from sklearn.ensemble import (
+    RandomForestClassifier,
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    RandomForestRegressor,
+)
+from sklearn.inspection import permutation_importance
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 from sklearn.neural_network import MLPRegressor
@@ -521,6 +527,8 @@ def feature_selection(
     n_features: int = 40,
     task: str = "classification",  # "classification" or "regression"
     use_gpu: bool = False,
+    importance_method: str | None = None,
+    importance_threshold: float = 0.0,
 ) -> pd.Index:
     """
     Robust feature selection pipeline that works for both classification and regression.
@@ -533,13 +541,16 @@ def feature_selection(
       5) Optional forward SFS if RFE still > n_features*1.5
     
     Returns the Index of selected feature names.
-    
+
     Args:
       - X: DataFrame of shape (n_samples, n_candidate_features)
       - y: Series of labels (binary/discrete for classification; continuous for regression)
       - n_features: number of features to select via RFE/SFS
       - task: "classification" or "regression"
       - use_gpu: enable GPU accelerated estimators
+      - importance_method: optional "shap" or "permutation" to compute
+        post-selection feature importances
+      - importance_threshold: prune features with importance below this value
     """
     start_time = time.time()
     print(f"🔍 Starting feature selection on {X.shape[1]} features for {task}...")
@@ -657,6 +668,62 @@ def feature_selection(
         final_features = rfe_features[sfs.get_support()]
     else:
         final_features = rfe_features
+
+    # Optional post-selection importance pruning
+    if importance_method:
+        if task == "classification":
+            imp_model = RandomForestClassifier(n_estimators=50, random_state=42)
+        else:
+            imp_model = RandomForestRegressor(n_estimators=50, random_state=42)
+
+        imp_model.fit(X_filtered[final_features], y)
+
+        if importance_method == "permutation":
+            result = permutation_importance(
+                imp_model,
+                X_filtered[final_features],
+                y,
+                n_repeats=5,
+                random_state=42,
+                n_jobs=-1,
+            )
+            importances = pd.Series(result.importances_mean, index=final_features)
+        elif importance_method == "shap":
+            try:
+                import shap
+
+                explainer = shap.TreeExplainer(imp_model)
+                shap_values = explainer.shap_values(X_filtered[final_features])
+                importances = pd.Series(
+                    np.abs(shap_values).mean(axis=0), index=final_features
+                )
+            except Exception as e:
+                print(f"SHAP importance failed: {e}; falling back to permutation")
+                result = permutation_importance(
+                    imp_model,
+                    X_filtered[final_features],
+                    y,
+                    n_repeats=5,
+                    random_state=42,
+                    n_jobs=-1,
+                )
+                importances = pd.Series(result.importances_mean, index=final_features)
+        else:
+            raise ValueError("importance_method must be 'shap' or 'permutation'")
+
+        importances.sort_values(ascending=False, inplace=True)
+        print("⭐ Feature importances:")
+        for feat, score in importances.items():
+            print(f"  {feat}: {score:.4f}")
+
+        if importance_threshold > 0:
+            keep = importances[importances >= importance_threshold].index
+            pruned = len(final_features) - len(keep)
+            if pruned > 0:
+                print(
+                    f"🗑️ Pruned {pruned} features below {importance_threshold}"
+                )
+            final_features = pd.Index(keep)
 
     print(f"⏱️ Feature selection completed in {time.time() - start_time:.2f}s")
     print(f"🎯 Final feature count: {len(final_features)}")


### PR DESCRIPTION
## Summary
- allow feature_selection to compute SHAP or permutation importance
- prune features below a configurable threshold
- show how to enable this step in `examples/train_classification.py`
- test new pruning logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c6ea46a88320a0efad295ec796b8