### PR TITLE
Add ML tracking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,17 @@ generate_dataset(
     task="classification",
     horizon=3,
     regime_target_encoding=True,
+    ml_logger="mlflow",  # or "wandb"
+    tracking_uri="file:./mlruns",
 )
 ```
 
 When enabled, the market ``regime`` feature is encoded against the target
 variable using `category_encoders.TargetEncoder`.
+
+Set ``ml_logger`` to ``"mlflow"`` or ``"wandb"`` (with optional ``tracking_uri``)
+to automatically record parameters, metrics and artifacts during dataset
+creation.
 
 ### Reduced Memory Footprint
 All numeric columns are stored as `float32` when datasets are generated. This

--- a/examples/train_classification.py
+++ b/examples/train_classification.py
@@ -39,6 +39,7 @@ def main():
         task="classification",
         importance_method="permutation",
         importance_threshold=0.01,
+        ml_logger="mlflow",
     )
     X_train = X_train[selected]
     X_test = X_test[selected]


### PR DESCRIPTION
## Summary
- enable MLflow or W&B logging for `feature_selection` and `generate_dataset`
- track parameters, metrics and artefacts when logger enabled
- demonstrate logging usage in training example and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416ad77b8c8320a683e59bf59c48bf