### PR TITLE
Add inference instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ regression targets.
 - [Labels](#labels)
 - [Build Dataset Details](#build-dataset-details)
 - [Example Training](#example-training)
+- [Inference](#inference)
 
 ## Installation
 Clone the repository and install the required Python packages:
@@ -122,3 +123,23 @@ metrics.
 
 For a full explanation of every feature engineered by `build_dataset.py`, see
 [the dedicated reference](docs/build_dataset.md).
+
+## Inference
+
+After training a model you can generate predictions on new data using
+`examples/predict.py`. The script expects the trained model, the processed
+dataset directory and a raw CSV file containing the OHLCV data to score.
+
+```bash
+python examples/predict.py \
+    --model-path models/classification/bundle_v1.joblib \
+    --dataset-path data/processed/classification \
+    --csv-path data/raw/BTCUSDT_1h.csv \
+    --version v1 \
+    --output-csv predictions.csv
+```
+
+Behind the scenes `prepare_inference_data` loads the saved feature mapping via
+`load_feature_mapper` to apply the same feature engineering pipeline and optional
+PCA transformation used during dataset generation. This ensures the model
+receives data in exactly the same format as it was trained on.


### PR DESCRIPTION
## Summary
- document how to run `examples/predict.py`
- explain role of `load_feature_mapper` and `prepare_inference_data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError/KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6841a89cddec8320b69c0ceda24bc6af