### PR TITLE
Add dataset options and chronological CV to training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,17 @@ provided script or the accompanying notebook.
 
 ### Using the script
 
+Specify the dataset directory and version to load. Add `--grid-search` to enable
+hyperparameter tuning.
+
 ```bash
-python examples/train_classification.py
+python examples/train_classification.py \
+    --data-dir data/processed/classification \
+    --version v1 \
+    [--grid-search]
 ```
+The optional `--grid-search` flag performs a small hyperparameter search over
+`LogisticRegression` before training.
 
 ### Using the notebook
 


### PR DESCRIPTION
## Summary
- update `train_classification.py` to accept dataset path, version, and optional grid search
- use `TimeSeriesSplit` for cross-validation
- allow saving model per dataset version
- document new script options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b1d512588320b58550264c85dcbf